### PR TITLE
Form submission several times before handling response is enabled

### DIFF
--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -51,7 +51,7 @@
                 doAutodisableButton(true, options);
                 //Running external definition
                 
-                if(typeof customBeforeSend === 'function'){
+                if (typeof customBeforeSend === 'function') {
                     customBeforeSend(xhr, settings);
                 }
                 
@@ -59,7 +59,7 @@
             },
             success : function(data, status, xhr){
                 //Running external definition
-                if(typeof customSuccess === 'function'){
+                if (typeof customSuccess === 'function') {
                     customSuccess(data, status, xhr);
                 }
                 
@@ -71,7 +71,7 @@
             },
             complete : function(jqXHR, textStatus){
                 doAutodisableButton(false, options);
-                if(typeof customComplete === 'function'){
+                if (typeof customComplete === 'function') {
                     customComplete(jqXHR, textStatus);
                 }
             }
@@ -87,8 +87,9 @@
      * param boolean disabled
      * param json options
      */
-    function doAutodisableButton(disabled, options){
-        if (options.submitButton){
+    function doAutodisableButton(disabled, options)
+    {
+        if (options.submitButton) {
             $(options.submitButton).prop('disabled', disabled);
         }
     }


### PR DESCRIPTION
A form can be submitted several times.
it should be necessary to change the plugin to handle it. Blocking the button (as this change is) and then, maybe, enabling it again when the submission is success. Or changing the functionality of the plugin.
