### PR TITLE
Load javascript on content change

### DIFF
--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -419,6 +419,10 @@
                 break;
         }
 
+        $(options.target).find('script').each(function(i) {
+            eval($(this).text());
+        });
+
         function removeClass() {
             if (options.removeClass) {
                 $(options.target).removeClass(options.removeClass);


### PR DESCRIPTION
Currently, if app loads mixed html/js content via ajaxcom, developer needs to specifically create callbacks to execute specific js functions. I think we should instead emulate default browser loading behaviour and load this javascript content by default.
