### PR TITLE
Open up symfony profiler on error response

### DIFF
--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -119,6 +119,12 @@
                     customComplete(jqXHR, textStatus, options);
                 }
 
+                // open up profiler on error response in debug mode
+                var sf = $('.sf-toolbar .sf-ajax-request-error');
+                if (textStatus == 'error' && sf.length) {
+                    window.location.href = sf.find('a:last').attr('href') + '?panel=exception';
+                }
+
                 $.ajaxcomProperties.isPopstateEvent = false;
             }
         };


### PR DESCRIPTION
This opens up symfony profiler on error response. What do you guys think? 

Is it too invasive? If so, how to make it less so? What are edge cases?