### PR TITLE
add support for callback within custom namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if (isset($_SERVER['X-AjaxCom'])) {
     );
     
     // NOTE: It is important to call callback() AFTER container() or modal()
-    // when you are affecting the rendered HTML inside the callback
+    // when you are manipulating the rendered DOM inside the callback;
     // otherwise the callback will be called before elements of DOM are loaded
     
     // Call funcname()
@@ -88,7 +88,7 @@ if (isset($_SERVER['X-AjaxCom'])) {
     // Call namespace.funcname()
     $handler->callback('namespace.funcname');
     // You can also specify parameters which will be passed as object to the funcion
-    $handler->callback('namespace.funcname', ['this' => 'will', 'be' => 'passed', 'as' => 'object', 'to' => 'function']);
+    $handler->callback('namespace.funcname', ['this' => 'will', 'be' => 'passed', 'as' => 'an object', 'to' => 'the function']);
     
 
     header('Content-type: application/json');

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ if (isset($_SERVER['X-AjaxCom'])) {
     $handler = new Handler();
     // Change URL to /newurl
     $handler->changeUrl('/newurl');
-    // Call funcname()
-    $handler->callback('funcname');
     // Append some html to an element
     $handler->container('#table')
         ->append('<tr><td>This is a new row</td></tr>');
@@ -80,6 +78,18 @@ if (isset($_SERVER['X-AjaxCom'])) {
             </div>
         </div>'
     );
+    
+    // NOTE: It is important to call callback() AFTER container() or modal()
+    // when you are affecting the rendered HTML inside the callback
+    // otherwise the callback will be called before elements of DOM are loaded
+    
+    // Call funcname()
+    $handler->callback('funcname');
+    // Call namespace.funcname()
+    $handler->callback('namespace.funcname');
+    // You can also specify parameters which will be passed as object to the funcion
+    $handler->callback('namespace.funcname', ['this' => 'will', 'be' => 'passed', 'as' => 'object', 'to' => 'function']);
+    
 
     header('Content-type: application/json');
     echo json_encode($handler->respond());

--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -379,8 +379,15 @@
 
     // Handle callbacks
     function handleCallback(options) {
-        if ($.isFunction(window[options.callFunction])) {
-            window[options.callFunction](options.params);
+        var namespaces = options.callFunction.split('.');
+        var context = window;
+
+        namespaces.forEach(function (item) {
+            context = context[item];
+        });
+
+        if ($.isFunction(context)) {
+            context(options.params);
         }
     }
 


### PR DESCRIPTION
Now you can use different callbacks `Common.callback` or `Common.library.callback` etc. instead just depending on callback defined within global namespace (`window`)