### PR TITLE
replace form serialization with FormData

### DIFF
--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -237,10 +237,7 @@
         // If form has been submitted by submit button with name,
         // then info about this button will be added into data variable.
         if (lastUsedIdentifiableSubmitButton != null) {
-            data.push({
-                name: lastUsedIdentifiableSubmitButton.name,
-                value: ''
-            });
+            data.append(lastUsedIdentifiableSubmitButton.name, '');
             lastUsedIdentifiableSubmitButton = null;
         }
 

--- a/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
+++ b/src/DM/AjaxCom/Resources/public/js/ajaxcom.js
@@ -232,7 +232,7 @@
             return;
         }
 
-        var data = $(form).serializeArray();
+        var data = new FormData(form);
 
         // If form has been submitted by submit button with name,
         // then info about this button will be added into data variable.
@@ -244,18 +244,14 @@
             lastUsedIdentifiableSubmitButton = null;
         }
 
-        $(form).find('input[type=file]').each(function(index, value) {
-            data.push({
-                name: $(value).attr('name'),
-                value: $(value).val()
-            });
-        });
-
         var defaults = {
             type: form.method,
             url: form.action,
             data: data,
-            submitButton: submitButton.length > 0? submitButton : null,
+            processData: false,
+            contentType: false,
+            cache: false,
+            submitButton: submitButton.length > 0 ? submitButton : null,
             element: event.currentTarget
         };
 


### PR DESCRIPTION
This change was implemented because modern secure browsers prepend file name with `C:\fakedata\`.
Using FormData with `processData: false` and `contentType: false` resolves this issue.

- all major modern browsers supports FormData (https://developer.mozilla.org/en/docs/Web/API/FormData)
- not sure how will behave older browsers, probably it would be nice to keep old function when FormData is not supported